### PR TITLE
Fix compiler type detection for clang and clang++.

### DIFF
--- a/de.marw.cmake/src/main/java/de/marw/cmake/cdt/language/settings/providers/CompileCommandsJsonParser.java
+++ b/de.marw.cmake/src/main/java/de/marw/cmake/cdt/language/settings/providers/CompileCommandsJsonParser.java
@@ -160,7 +160,7 @@ public class CompileCommandsJsonParser extends AbstractExecutableExtensionBase
     // construct matchers that detect the tool name...
     final String REGEX_CMD_HEAD =
         "^(.*?" + Pattern.quote(File.separator) + ")(";
-    final String REGEX_CMD_TAIL = ")";
+    final String REGEX_CMD_TAIL = ")\\s";
     for (Entry<String, IToolCommandlineParser> entry : knownCmdParsers
         .entrySet()) {
       // 'cc' -> matches


### PR DESCRIPTION
The compiler type detection uses `lookingAt` matching method
which would successfully match `clang` for `clang++`. Adding
`\s` to the tail regex to make sure the compiler name matches
completely.