### PR TITLE
WIP: fix command line argument parsing (RFC)

### DIFF
--- a/de.marw.cmake/src/main/java/de/marw/cmake/cdt/language/settings/providers/CompileCommandsJsonParser.java
+++ b/de.marw.cmake/src/main/java/de/marw/cmake/cdt/language/settings/providers/CompileCommandsJsonParser.java
@@ -399,8 +399,7 @@ public class CompileCommandsJsonParser extends AbstractExecutableExtensionBase
       return false; // no matching parser found
     }
     // found a matching command-line parser
-    processCommandLine(storage, projectEntries, preferredCmdlineParser.parser, sourceFile,
-          preferredCmdlineParser.getReducedCommandLine());
+    processCommandLine(storage, projectEntries, preferredCmdlineParser.parser, sourceFile, line);
     return true; // could process command line
   }
 


### PR DESCRIPTION
It looks like that reducedCommandLine is too reduced. By providing the
complete line, includes are actually found and projectEntries is not
empty.

However, the fix is not completed: the includes are still not taken by
the indexer.

Signed-off-by: Francis Giraldeau <francis.giraldeau@gmail.ca>