### PR TITLE
Fix typo in documentation

### DIFF
--- a/de.marw.cdt.cmake.core/doc/html/home.html
+++ b/de.marw.cdt.cmake.core/doc/html/home.html
@@ -42,7 +42,7 @@
 	<li>Takes your <em>CMakeLists.txt</em> as the source of truth.</li>
 	<li>Supports the <code><a href="https://github.com/ninja-build/ninja">ninja</a></code> build system.</li>
 	<li>Aims to make Eclipse project cross-platform compatible without the need to change platform-specifc project settings.</li>
-	<li>Its Language Settings Provider can feed include paths and pre-processor symbols frrom cmake to the CDT-Indexer.</li>
+	<li>Its Language Settings Provider can feed include paths and pre-processor symbols from cmake to the CDT-Indexer.</li>
     </ul>
   <h2>Project Home</h2>
   <p>


### PR DESCRIPTION
Just a small typo fix in the documentation.