### PR TITLE
add support for external build directories

### DIFF
--- a/de.marw.cdt.cmake.core/plugin.xml
+++ b/de.marw.cdt.cmake.core/plugin.xml
@@ -87,6 +87,14 @@
       </super>
    </extension>
    <extension
+         id="ConfigurationError"
+         name="CMake Configuration Problem"
+         point="org.eclipse.core.resources.markers">
+      <super
+            type="org.eclipse.core.resources.problemmarker">
+      </super>
+   </extension>
+   <extension
          id="BuildRunnerError"
          name="CMakecache.txt Problem"
          point="org.eclipse.core.resources.markers">

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/internal/settings/CMakePreferences.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/internal/settings/CMakePreferences.java
@@ -47,6 +47,7 @@ public class CMakePreferences {
   private static final String ELEM_OPTIONS = "options";
   private static final String ATTR_CACHE_FILE = "cacheEntriesFile";
   private static final String ATTR_BUILD_DIR = "buildDir";
+  private static final String ATTR_LINKED_FOLDER_NAME = "linkedFolderName";
 
   private boolean warnNoDev, debugTryCompile, debugOutput, trace,
       warnUnitialized, warnUnused;
@@ -55,6 +56,8 @@ public class CMakePreferences {
   private List<CmakeUnDefine> undefines = new ArrayList<>(0);
   private String buildDirectory;
   private String cacheFile;
+  
+  private String linkedFolderName;
 
   private LinuxPreferences linuxPreferences = new LinuxPreferences();
 
@@ -113,6 +116,7 @@ public class CMakePreferences {
         warnUnused = Boolean.parseBoolean(child.getAttribute(ATTR_WARN_UNUSED));
         cacheFile = child.getAttribute(ATTR_CACHE_FILE);
         buildDirectory= parent.getAttribute(ATTR_BUILD_DIR);
+        linkedFolderName = parent.getAttribute(ATTR_LINKED_FOLDER_NAME);
       } else if (ELEM_DEFINES.equals(child.getName())) {
         // defines...
         Util.deserializeCollection(defines, new CmakeDefineSerializer(), child);
@@ -184,6 +188,12 @@ public class CMakePreferences {
       parent.setAttribute(ATTR_BUILD_DIR, buildDirectory);
     } else {
       parent.removeAttribute(ATTR_CACHE_FILE);
+    }
+    
+    if (linkedFolderName!= null) {
+      parent.setAttribute(ATTR_LINKED_FOLDER_NAME, linkedFolderName);
+    } else {
+      parent.removeAttribute(ATTR_LINKED_FOLDER_NAME);
     }
 
     // defines...
@@ -360,5 +370,13 @@ public class CMakePreferences {
    */
   public void setClearCache(boolean clearCache) {
     this.clearCache= clearCache;
+  }
+
+  public void setLinkedFolderName(String linkedFolderName) {
+    this.linkedFolderName = linkedFolderName;
+  }
+
+  public String getLinkedFolderName() {
+    return linkedFolderName;
   }
 }


### PR DESCRIPTION
First part of PR #88 with comments took into consideration.

This pull request adds support for absolute build directories without any additional configuration. Currently, if you want to build into an external directory, you have to link the directory into the project manually and then specify the local path to the directory link. With this change the directory link is created automatically if it is detected that the path is absolute. The directory link will reside in the project root and will be called "build_output" by default. You can set another name in the CMake Configuration UI. For relative paths (e.g. manually linked absolute directories) the behavior does not change.

Problems will be reported by creating an error marker on the project after clicking 'Apply' in the configuration UI.

Setting a linked directory name to a name that currently does exist in the project generates a warning and does not delete any files. Special case: the existing directory is a linked directory --> Link is changed to the destination set in the configuration.

The directory link is only generated after clicking apply in the configuration UI OR if the folder does not exist prior to the build.